### PR TITLE
Active class

### DIFF
--- a/scrollTrigger.js
+++ b/scrollTrigger.js
@@ -6,7 +6,8 @@
 
     var settings = $.extend({
           offset: 60,
-          target: this
+          target: this,
+          active: 'scrolltrig--active'
         }, options),
         el = this;
 
@@ -19,15 +20,15 @@
 
         if(settings.target != el) {
           if(sT > $(el[0]).offset().top - wH + settings.offset) {
-            $(settings.target).addClass('active');
+            $(settings.target).addClass(settings.active);
           } else {
-            $(settings.target).removeClass('active');
+            $(settings.target).removeClass(settings.active);
           }
         } else {
           if(sT > $(v).offset().top - wH + settings.offset) {
-            $(v).addClass('active');
+            $(v).addClass(settings.active);
           } else {
-            $(v).removeClass('active');
+            $(v).removeClass(settings.active);
           }
         }
 

--- a/scrollTrigger.js
+++ b/scrollTrigger.js
@@ -5,9 +5,9 @@
   $.fn.scrollTrigger = function(options) {
 
     var settings = $.extend({
+          active: 'scrolltrig--active',
           offset: 60,
-          target: this,
-          active: 'scrolltrig--active'
+          target: this
         }, options),
         el = this;
 


### PR DESCRIPTION
This enables users to customize the active class when calling the scrollTrigger method. The default active class is given the `scrolltrig` prefix and the BEM double hyphen to indicate a state variation. 
