### PR TITLE
Correct calculation of target element position

### DIFF
--- a/scrollTrigger.js
+++ b/scrollTrigger.js
@@ -14,17 +14,16 @@
     var activate = function() {
 
       el.each(function(k, v) {
-        var sT = $(window).scrollTop(),
-            wH = $(window).height();
+        var sT = $(window).scrollTop();
 
         if(settings.target != el) {
-          if(sT > $(el[0]).offset().top - wH + settings.offset) {
+          if(sT > $(el[0]).offset().top - settings.offset) {
             $(settings.target).addClass('active');
           } else {
             $(settings.target).removeClass('active');
           }
         } else {
-          if(sT > $(v).offset().top - wH + settings.offset) {
+          if(sT > $(v).offset().top - settings.offset) {
             $(v).addClass('active');
           } else {
             $(v).removeClass('active');


### PR DESCRIPTION
I understand the utility of this plugin is to add or remove a class when an element reaches the top of the viewport or is x pixels from the top of the viewport if an offset value is specified. If this understanding is correct, this pull request corrects inaccurate calculation of element position relative to the active/inactive range. 
